### PR TITLE
Switch to SWAL2-neutral, a smaller/faster library

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "react-markdown": "8.0.3",
     "react-masonry-css": "^1.0.16",
     "sass": "^1.54.9",
-    "sweetalert2": "^11.4.33",
+    "sweetalert2-neutral": "^11.4.33",
     "sweetalert2-react-content": "^5.0.3",
     "swr": "^1.3.0",
     "tailwindcss": "^3.1.8",


### PR DESCRIPTION
Just randomly noticed you were using the upstream one, so I wanted to bring up this fork. It's mostly 1:1. Allowing for you to specify which, if any, anti-war messages you want to display to users of browsers with RU language, not having to work with a piece of protestware. Unfortunately, this change was not accepted to the upstream package, hence the existence of a fork.

Have a good day :)